### PR TITLE
Do nothing if status is already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,27 @@
 
         config :authy,
           api_key: System.get_env("AUTHY_API_KEY")
+
+## Usage
+
+You must add a map `authy` to `conn.assigns` that contains the requisite members for each step; see the strategy docs for details. The reason for this is to avoid having an endpoint to which you can just pass a `phone_number` and allow spamming of people's phones using your twilio account.
+
+Setting `conn.status` to anything but nil will skip the strategy.
+
+### Example
+
+```
+plug :lookup_phone_number
+plug Ueberauth
+
+... <callbacks etc>
+
+defp lookup_phone_number(conn = %{params: ${user_id: user_id}}) do
+  case User.find(user_id) do
+    user = %User{} -> assign(:authy, %{phone_number: user.phone_number})
+    _ -> put_status(404)
+  end
+end
+
+...
+```

--- a/lib/ueberauth/strategy/authy/phone_verification.ex
+++ b/lib/ueberauth/strategy/authy/phone_verification.ex
@@ -29,7 +29,7 @@ defmodule Ueberauth.Strategy.Authy.PhoneVerification do
 
   Uses [set_errors!](https://github.com/ueberauth/ueberauth/blob/v0.2.0/lib/ueberauth/strategies/helpers.ex#L109) on error, placing :ueberauth_failure in assigns.
 
-  *Does nothing if conn.status is not nil*
+  *Does nothing (passes conn as-is) if conn.status is not nil*
 
   See https://docs.authy.com/phone_verification.html#sending-the-verification-code
   """
@@ -54,7 +54,7 @@ defmodule Ueberauth.Strategy.Authy.PhoneVerification do
 
   Uses [set_errors!](https://github.com/ueberauth/ueberauth/blob/v0.2.0/lib/ueberauth/strategies/helpers.ex#L109) on error, placing :ueberauth_failure in assigns.
 
-  *Does nothing if conn.status is not nil*
+  *Does nothing (passes conn as-is) if conn.status is not nil*
 
   See https://docs.authy.com/phone_verification.html#verifying-the-verification-code
   """

--- a/lib/ueberauth/strategy/authy/phone_verification.ex
+++ b/lib/ueberauth/strategy/authy/phone_verification.ex
@@ -29,14 +29,20 @@ defmodule Ueberauth.Strategy.Authy.PhoneVerification do
 
   Uses [set_errors!](https://github.com/ueberauth/ueberauth/blob/v0.2.0/lib/ueberauth/strategies/helpers.ex#L109) on error, placing :ueberauth_failure in assigns.
 
+  *Does nothing if conn.status is not nil*
+
   See https://docs.authy.com/phone_verification.html#sending-the-verification-code
   """
-  def handle_request!(conn = %{assigns: %{authy: authy = %{phone_number: _}}}) do
+  def handle_request!(conn = %{assigns: %{authy: authy = %{phone_number: _}}, status: nil}) do
     params = authy_with_defaults(conn) |> Map.take([:via, :phone_number, :country_code, :locale, :custom_message])
     case Authy.PhoneVerification.start(params) do
       {:ok, _} -> conn
       {:error, message} -> set_errors!(conn, [error("authy", message)])
     end
+  end
+
+  def handle_request!(conn) do
+    conn
   end
 
   @doc """
@@ -48,14 +54,20 @@ defmodule Ueberauth.Strategy.Authy.PhoneVerification do
 
   Uses [set_errors!](https://github.com/ueberauth/ueberauth/blob/v0.2.0/lib/ueberauth/strategies/helpers.ex#L109) on error, placing :ueberauth_failure in assigns.
 
+  *Does nothing if conn.status is not nil*
+
   See https://docs.authy.com/phone_verification.html#verifying-the-verification-code
   """
-  def handle_callback!(conn = %{assigns: %{authy: authy = %{phone_number: _, verification_code: _}}}) do
+  def handle_callback!(conn = %{assigns: %{authy: authy = %{phone_number: _, verification_code: _}}, status: nil}) do
     params = authy_with_defaults(conn) |> Map.take([:phone_number, :country_code, :verification_code])
     case Authy.PhoneVerification.check(authy) do
       {:ok, _} -> conn
       {:error, message} -> set_errors!(conn, [error("authy", message)])
     end
+  end
+
+  def handle_callback!(conn) do
+    conn
   end
 
   defp authy_with_defaults(conn = %{assigns: %{authy: authy}}) do


### PR DESCRIPTION
Allows for a plug in front of it to set 400 or 404 etc if the authy map
cannot be constructed for some reason
